### PR TITLE
Add Ability to Toggle Posts as Answered Vs. Unanswered

### DIFF
--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -16,6 +16,8 @@ PostObject:
       type: number
     deleted:
       type: boolean
+    answered:
+      type: number
     upvotes:
       type: number
     downvotes:

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -67,6 +67,8 @@ get:
                           type: number
                         deleted:
                           type: number
+                        answered:
+                          type: number
                         upvotes:
                           type: number
                         downvotes:
@@ -74,6 +76,8 @@ get:
                         bookmarks:
                           type: number
                         deleterUid:
+                          type: number
+                        answererUid:
                           type: number
                         edited:
                           type: number

--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -40,11 +40,15 @@ get:
                     type: number
                   deleted:
                     type: number
+                  answered:
+                    type: number
                   upvotes:
                     type: number
                   downvotes:
                     type: number
                   deleterUid:
+                    type: number
+                  answererUid:
                     type: number
                   edited:
                     type: number

--- a/public/openapi/write/posts/pid/replies.yaml
+++ b/public/openapi/write/posts/pid/replies.yaml
@@ -45,6 +45,8 @@ get:
                           type: number
                         deleted:
                           type: number
+                        answered:
+                          type: number
                         upvotes:
                           type: number
                         downvotes:

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -40,6 +40,9 @@ define('forum/topic/events', [
 		'posts.bookmark': togglePostBookmark,
 		'posts.unbookmark': togglePostBookmark,
 
+		'posts.answer': toggleAnswered,
+		'posts.unanswer': toggleAnswered,
+
 		'posts.upvote': togglePostVote,
 		'posts.downvote': togglePostVote,
 		'posts.unvote': togglePostVote,
@@ -220,6 +223,10 @@ define('forum/topic/events', [
 
 		el.find('[component="post/bookmark/on"]').toggleClass('hidden', !data.isBookmarked);
 		el.find('[component="post/bookmark/off"]').toggleClass('hidden', data.isBookmarked);
+	}
+
+	function toggleAnswered(data) {
+		console.log('hi');
 	}
 
 	function togglePostVote(data) {

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -225,7 +225,7 @@ define('forum/topic/events', [
 		el.find('[component="post/bookmark/off"]').toggleClass('hidden', data.isBookmarked);
 	}
 
-	function toggleAnswered(data) {
+	function toggleAnswered() {
 		console.log('hi');
 	}
 

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -226,7 +226,7 @@ define('forum/topic/events', [
 	}
 
 	function toggleAnswered() {
-		console.log('hi');
+		console.log('Toggling answered field.');
 	}
 
 	function togglePostVote(data) {

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -156,6 +156,14 @@ postsAPI.edit = async function (caller, data) {
 	return returnData;
 };
 
+postsAPI.answer = async function (caller, data) {
+	return await apiHelpers.postCommand(caller, 'answer', 'answered', '', data);
+};
+
+postsAPI.unanswer = async function (caller, data) {
+	return await apiHelpers.postCommand(caller, 'unanswer', 'answered', '', data);
+};
+
 postsAPI.delete = async function (caller, data) {
 	await deleteOrRestore(caller, data, {
 		command: 'delete',

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -153,6 +153,18 @@ Posts.unbookmark = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Posts.answer = async (req, res) => {
+	const data = await mock(req);
+	await api.posts.answer(req, data);
+	helpers.formatApiResponse(200, res);
+};
+
+Posts.unanswer = async (req, res) => {
+	const data = await mock(req);
+	await api.posts.unanswer(req, data);
+	helpers.formatApiResponse(200, res);
+};
+
 Posts.getDiffs = async (req, res) => {
 	helpers.formatApiResponse(200, res, await api.posts.getDiffs(req, { ...req.params }));
 };

--- a/src/posts/answer.js
+++ b/src/posts/answer.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const db = require('../database');
+const plugins = require('../plugins');
+
+module.exports = function (Posts) {
+	Posts.answer = async function (pid, uid) {
+		return await toggleAnswered('answer', pid, uid);
+	};
+
+    Posts.unanswer = async function (pid, uid) {
+        return await toggleAnswered('unanswer', pid, uid);
+    };
+
+	async function toggleAnswered(type, pid, uid) {
+        const isAnswering = type === 'answer';
+        await plugins.hooks.fire(`filter:post.${type}`, { pid: pid, uid: uid });
+
+        await Posts.setPostFields(pid, {
+			answered: isAnswering ? 1 : 0,
+			answererUid: isAnswering ? uid : 0,
+		});
+
+		const postData = await Posts.getPostFields(pid, ['pid', 'tid', 'uid', 'content', 'timestamp']);
+
+		return postData;
+	};
+}

--- a/src/posts/answer.js
+++ b/src/posts/answer.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const db = require('../database');
 const plugins = require('../plugins');
 
 module.exports = function (Posts) {
@@ -8,15 +7,15 @@ module.exports = function (Posts) {
 		return await toggleAnswered('answer', pid, uid);
 	};
 
-    Posts.unanswer = async function (pid, uid) {
-        return await toggleAnswered('unanswer', pid, uid);
-    };
+	Posts.unanswer = async function (pid, uid) {
+		return await toggleAnswered('unanswer', pid, uid);
+	};
 
 	async function toggleAnswered(type, pid, uid) {
-        const isAnswering = type === 'answer';
-        await plugins.hooks.fire(`filter:post.${type}`, { pid: pid, uid: uid });
+		const isAnswering = type === 'answer';
+		await plugins.hooks.fire(`filter:post.${type}`, { pid: pid, uid: uid });
 
-        await Posts.setPostFields(pid, {
+		await Posts.setPostFields(pid, {
 			answered: isAnswering ? 1 : 0,
 			answererUid: isAnswering ? uid : 0,
 		});
@@ -24,5 +23,5 @@ module.exports = function (Posts) {
 		const postData = await Posts.getPostFields(pid, ['pid', 'tid', 'uid', 'content', 'timestamp']);
 
 		return postData;
-	};
-}
+	}
+};

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
 	'upvotes', 'downvotes', 'deleterUid', 'edited',
-	'replies', 'bookmarks',
+	'replies', 'bookmarks', 'answered', 'answererUid',
 ];
 
 module.exports = function (Posts) {

--- a/src/posts/index.js
+++ b/src/posts/index.js
@@ -23,6 +23,7 @@ require('./recent')(Posts);
 require('./tools')(Posts);
 require('./votes')(Posts);
 require('./bookmarks')(Posts);
+require('./answer')(Posts);
 require('./queue')(Posts);
 require('./diffs')(Posts);
 require('./uploads')(Posts);

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -20,7 +20,7 @@ module.exports = function (Posts) {
 		options.parse = options.hasOwnProperty('parse') ? options.parse : true;
 		options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-		const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
+		const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'answered'].concat(options.extraFields);
 
 		let posts = await Posts.getPostsFields(pids, fields);
 		posts = posts.filter(Boolean);

--- a/test/posts.js
+++ b/test/posts.js
@@ -281,6 +281,14 @@ describe('Post\'s', () => {
 		});
 	});
 
+	describe('answering', async () => {
+		it('should mark post answered', async () => {
+			const data = await apiPosts.answer({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+			const isAnswered = await posts.getPostField(postData.pid, 'answered');
+			assert.strictEqual(isAnswered, 1);
+		});
+	});
+
 	describe('post tools', () => {
 		it('should error if data is invalid', (done) => {
 			socketPosts.loadPostTools({ uid: globalModUid }, null, (err) => {


### PR DESCRIPTION
- Updated Yaml files `src/posts/data.js` and `src/posts/data.js` to include new field in Jsons. 
- Updated `src/api/posts.js` to include an answer and unanswer API function.
- Updated `src/controllers/write/posts.js` to include answer and unanswer functions that call their API counterparts and format the response.
- Created `src/posts/answer.js` to handle the toggling logic and the logic of the API functions.
- Created an event in `public/src/client/topic/events.js` which will handle UI change in next PR.
- Added a test case to `test/posts.js`

resolves #3 