### PR TITLE
Adding Answer Dropdown Toggle to Topics

### DIFF
--- a/.github/workflows/f24_nodebb-yerim-test.yml
+++ b/.github/workflows/f24_nodebb-yerim-test.yml
@@ -1,0 +1,62 @@
+# Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
+# More GitHub Actions for Azure: https://github.com/Azure/actions
+
+name: Build and deploy Node.js app to Azure Web App - nodebb-yerim-test
+
+on:
+  push:
+    branches:
+      - f24
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js version
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+
+      - name: npm install, build, and test
+        run: |
+          npm install
+          npm run build --if-present
+          npm run test --if-present
+
+      - name: Zip artifact for deployment
+        run: zip release.zip ./* -r
+
+      - name: Upload artifact for deployment job
+        uses: actions/upload-artifact@v3
+        with:
+          name: node-app
+          path: release.zip
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: 'Production'
+      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+
+    steps:
+      - name: Download artifact from build job
+        uses: actions/download-artifact@v3
+        with:
+          name: node-app
+
+      - name: Unzip artifact for deployment
+        run: unzip release.zip
+
+      - name: 'Deploy to Azure Web App'
+        id: deploy-to-webapp
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: 'nodebb-yerim-test'
+          slot-name: 'Production'
+          publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_7987CBBA808B4A44A7974B909CC34E48 }}
+          package: .

--- a/nodebb-theme-slackers/templates/partials/topic/topic-menu-list.tpl
+++ b/nodebb-theme-slackers/templates/partials/topic/topic-menu-list.tpl
@@ -7,12 +7,12 @@
 	<a component="topic/unlock" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !locked }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-unlock text-secondary"></i> [[topic:thread-tools.unlock]]</a>
 </li>
 
-<li {{{ if locked }}}hidden{{{ end }}}>
-	<a component="topic/lock" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if locked }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-lock text-secondary"></i> [[topic:thread-tools.answer]]</a>
+<li {{{ if ed }}}hidden{{{ end }}}>
+	<a component="topic/answer" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if answered }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-lock text-secondary"></i> [[topic:thread-tools.answer]]</a>
 </li>
 
-<li {{{ if !locked }}}hidden{{{ end }}}>
-	<a component="topic/unlock" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !locked }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-unlock text-secondary"></i> [[topic:thread-tools.unanswer]]</a>
+<li {{{ if !answered }}}hidden{{{ end }}}>
+	<a component="topic/unanswer" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !answered }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-unlock text-secondary"></i> [[topic:thread-tools.unanswer]]</a>
 </li>
 
 <li {{{ if pinned }}}hidden{{{ end }}}>

--- a/nodebb-theme-slackers/templates/partials/topic/topic-menu-list.tpl
+++ b/nodebb-theme-slackers/templates/partials/topic/topic-menu-list.tpl
@@ -1,0 +1,82 @@
+{{{ if privileges.editable }}}
+<li {{{ if locked }}}hidden{{{ end }}}>
+	<a component="topic/lock" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if locked }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-lock text-secondary"></i> [[topic:thread-tools.lock]]</a>
+</li>
+
+<li {{{ if !locked }}}hidden{{{ end }}}>
+	<a component="topic/unlock" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !locked }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-unlock text-secondary"></i> [[topic:thread-tools.unlock]]</a>
+</li>
+
+<li {{{ if locked }}}hidden{{{ end }}}>
+	<a component="topic/lock" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if locked }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-lock text-secondary"></i> [[topic:thread-tools.answer]]</a>
+</li>
+
+<li {{{ if !locked }}}hidden{{{ end }}}>
+	<a component="topic/unlock" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !locked }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-unlock text-secondary"></i> [[topic:thread-tools.unanswer]]</a>
+</li>
+
+<li {{{ if pinned }}}hidden{{{ end }}}>
+	<a component="topic/pin" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if pinned }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-thumb-tack text-secondary"></i> [[topic:thread-tools.pin]]</a>
+</li>
+
+<li {{{ if !pinned }}}hidden{{{ end }}}>
+	<a component="topic/unpin" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !pinned }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-thumb-tack fa-rotate-90 text-secondary"></i> [[topic:thread-tools.unpin]]</a>
+</li>
+
+<li>
+	<a component="topic/move" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-arrows text-secondary"></i> [[topic:thread-tools.move]]</a>
+</li>
+
+<li>
+	<a component="topic/merge" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-code-fork text-secondary"></i> [[topic:thread-tools.merge]]</a>
+</li>
+
+<li>
+	<a component="topic/fork" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-code-fork text-secondary"></i> [[topic:thread-tools.fork]]</a>
+</li>
+
+<li>
+	<a component="topic/tag" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-tag text-secondary"></i> [[topic:thread-tools.tag]]</a>
+</li>
+
+{{{ if !scheduled }}}
+<li>
+	<a component="topic/move-posts" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-arrows text-secondary"></i> [[topic:thread-tools.move-posts]]</a>
+</li>
+{{{ end }}}
+
+<li>
+	<a component="topic/mark-unread-for-all" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-inbox text-secondary"></i> [[topic:thread-tools.markAsUnreadForAll]]</a>
+</li>
+
+<li class="dropdown-divider"></li>
+{{{ end }}}
+
+{{{ if privileges.deletable }}}
+<li {{{ if deleted }}}hidden{{{ end }}}>
+	<a component="topic/delete" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if deleted }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-trash-o text-secondary"></i> [[topic:thread-tools.delete]]</a>
+</li>
+
+{{{ if !scheduled }}}
+<li {{{ if !deleted }}}hidden{{{ end }}}>
+	<a component="topic/restore" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !deleted }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-history text-secondary"></i> [[topic:thread-tools.restore]]</a>
+</li>
+{{{ end }}}
+
+{{{ if privileges.purge }}}
+<li {{{ if !deleted }}}hidden{{{ end }}}>
+	<a component="topic/purge" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !deleted }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-eraser text-secondary"></i> [[topic:thread-tools.purge]]</a>
+</li>
+{{{ end }}}
+{{{ if privileges.isAdminOrMod }}}
+<li>
+	<a component="topic/delete/posts" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-trash-o text-secondary"></i> [[topic:thread-tools.delete-posts]]</a>
+</li>
+{{{ end }}}
+
+{{{ each thread_tools }}}
+<li>
+	<a href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {./class}" role="menuitem"><i class="fa fa-fw text-secondary {./icon}"></i> {./title}</a>
+</li>
+{{{ end }}}
+{{{ end }}}

--- a/nodebb-theme-slackers/templates/partials/topics_list.tpl
+++ b/nodebb-theme-slackers/templates/partials/topics_list.tpl
@@ -1,0 +1,135 @@
+<ul component="category" class="topics-list list-unstyled" itemscope itemtype="http://www.schema.org/ItemList" data-nextstart="{nextStart}" data-set="{set}">
+
+	{{{ each topics }}}
+	<li component="category/topic" class="category-item hover-parent border-bottom py-3 py-lg-4 d-flex flex-column flex-lg-row align-items-start {function.generateTopicClass}" <!-- IMPORT partials/data/category.tpl -->>
+		<link itemprop="url" content="{config.relative_path}/topic/{./slug}" />
+		<meta itemprop="name" content="{function.stripTags, ./title}" />
+		<meta itemprop="itemListOrder" content="descending" />
+		<meta itemprop="position" content="{increment(./index, "1")}" />
+		<a id="{./index}" data-index="{./index}" component="topic/anchor"></a>
+
+		<div class="d-flex p-0 col-12 col-lg-7 gap-2 gap-lg-3 pe-1 align-items-start {{{ if config.theme.mobileTopicTeasers }}}mb-2 mb-lg-0{{{ end }}}">
+			<div class="flex-shrink-0 position-relative">
+				<a class="text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}">
+					{buildAvatar(./user, "40px", true, "avatar avatar-tooltip")}
+				</a>
+				{{{ if showSelect }}}
+				<div class="checkbox position-absolute top-100 start-50 translate-middle-x pt-2 m-0 d-none d-lg-flex" style="max-width:max-content">
+					<i component="topic/select" class="fa text-muted pointer fa-square-o p-1 hover-visible"></i>
+				</div>
+				{{{ end }}}
+			</div>
+			<div class="flex-grow-1 d-flex flex-wrap gap-1 position-relative">
+				<h3 component="topic/header" class="title text-break fs-5 fw-semibold m-0 tracking-tight w-100 {{{ if showSelect }}}me-4 me-lg-0{{{ end }}}">
+					<a class="text-reset" href="{{{ if topics.noAnchor }}}#{{{ else }}}{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}{{{ end }}}">{./title}</a>
+				</h3>
+				<span component="topic/labels" class="d-flex flex-wrap gap-1 w-100">
+					<span component="topic/watched" class="badge border border-gray-300 text-body {{{ if !./followed }}}hidden{{{ end }}}">
+						<i class="fa fa-bell-o"></i>
+						<span>[[topic:watching]]</span>
+					</span>
+					<span component="topic/ignored" class="badge border border-gray-300 text-body {{{ if !./ignored }}}hidden{{{ end }}}">
+						<i class="fa fa-eye-slash"></i>
+						<span>[[topic:ignoring]]</span>
+					</span>
+					<span component="topic/scheduled" class="badge border border-gray-300 text-body {{{ if !./scheduled }}}hidden{{{ end }}}">
+						<i class="fa fa-clock-o"></i>
+						<span>[[topic:scheduled]]</span>
+					</span>
+					<span component="topic/pinned" class="badge border border-gray-300 text-body {{{ if (./scheduled || !./pinned) }}}hidden{{{ end }}}">
+						<i class="fa fa-thumb-tack"></i>
+						<span>{{{ if !./pinExpiry }}}[[topic:pinned]]{{{ else }}}[[topic:pinned-with-expiry, {isoTimeToLocaleString(./pinExpiryISO, config.userLang)}]]{{{ end }}}</span>
+					</span>
+					<span component="topic/locked" class="badge border border-gray-300 text-body {{{ if !./locked }}}hidden{{{ end }}}">
+						<i class="fa fa-lock"></i>
+						<span>[[topic:locked]]</span>
+					</span>
+                    <span component="topic/answered" class="badge border border-gray-300 text-body {{{ if !./answered }}}hidden{{{ end }}}">
+						<i class="fa fa-lock"></i>
+						<span>[[topic:answered]]</span>
+					</span>
+					<span component="topic/moved" class="badge border border-gray-300 text-body {{{ if !./oldCid }}}hidden{{{ end }}}">
+						<i class="fa fa-arrow-circle-right"></i>
+						<span>[[topic:moved]]</span>
+					</span>
+					{{{each ./icons}}}<span class="lh-1">{@value}</span>{{{end}}}
+
+					{{{ if !template.category }}}
+					{function.buildCategoryLabel, ./category, "a", "border"}
+					{{{ end }}}
+
+					<span data-tid="{./tid}" component="topic/tags" class="lh-1 tag-list hidden-xs d-flex flex-wrap gap-1 {{{ if !./tags.length }}}hidden{{{ end }}}">
+						{{{ each ./tags }}}
+						<a href="{config.relative_path}/tags/{./valueEncoded}"><span class="badge border border-gray-300 fw-normal tag tag-class-{./class}" data-tag="{./value}">{./valueEscaped}</span></a>
+						{{{ end }}}
+					</span>
+
+					<div class="d-flex gap-1 d-block d-lg-none w-100">
+						<span class="badge text-body border stats text-xs text-muted">
+							<i class="fa-regular fa-fw fa-message"></i>
+							<span component="topic/post-count" class="fw-normal">{humanReadableNumber(./postcount, 0)}</span>
+						</span>
+
+						<a href="{config.relative_path}/topic/{./slug}{{{ if (./teaser.timestampISO && !config.theme.mobileTopicTeasers) }}}/{./teaser.index}{{{ end }}}" class="border badge bg-transparent text-muted fw-normal timeago" title="{{{ if (./teaser.timestampISO && !config.theme.mobileTopicTeasers) }}}{./teaser.timestampISO}{{{ else }}}{./timestampISO}{{{ end }}}"></a>
+					</div>
+
+					<a href="{config.relative_path}/topic/{./slug}" class="d-none d-lg-block badge bg-transparent text-muted fw-normal timeago" title="{./timestampISO}"></a>
+				</span>
+				{{{ if showSelect }}}
+				<div class="checkbox position-absolute top-0 end-0 m-0 d-flex d-lg-none" style="max-width:max-content">
+					<i component="topic/select" class="fa fa-square-o text-muted pointer p-1"></i>
+				</div>
+				{{{ end }}}
+			</div>
+			{{{ if ./thumbs.length }}}
+			<a class="topic-thumbs position-relative text-decoration-none flex-shrink-0 d-none d-xl-block" href="{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}" aria-label="[[topic:thumb-image]]">
+				<img class="topic-thumb rounded-1 bg-light" style="width:auto;max-width: 5.33rem;height: 3.33rem;object-fit: contain;" src="{./thumbs.0.url}" alt=""/>
+				<span data-numthumbs="{./thumbs.length}" class="px-1 position-absolute top-0 start-100 translate-middle badge rounded text-bg-info" style="z-index: 1;">+{increment(./thumbs.length, "-1")}</span>
+			</a>
+			{{{ end }}}
+		</div>
+
+		<div class="d-flex p-0 col-lg-5 col-12 align-content-stretch">
+			<div class="meta stats d-none d-lg-grid col-6 gap-1 pe-2 text-muted" style="grid-template-columns: 1fr 1fr 1fr;">
+				{{{ if !reputation:disabled }}}
+				<div class="stats-votes card card-header border-0 p-2 overflow-hidden rounded-1 d-flex flex-column align-items-center">
+					<span class="fs-5 ff-secondary lh-1" title="{./votes}">{humanReadableNumber(./votes, 0)}</span>
+					<span class="d-none d-xl-flex text-lowercase text-xs">[[global:votes]]</span>
+					<i class="d-xl-none fa fa-fw text-xs text-muted opacity-75 fa-chevron-up"></i>
+				</div>
+				{{{ end }}}
+				<div class="stats-postcount card card-header border-0 p-2 overflow-hidden rounded-1 d-flex flex-column align-items-center">
+					<span class="fs-5 ff-secondary lh-1" title="{./postcount}">{humanReadableNumber(./postcount, 0)}</span>
+					<span class="d-none d-xl-flex text-lowercase text-xs">[[global:posts]]</span>
+					<i class="d-xl-none fa-regular fa-fw text-xs text-muted opacity-75 fa-message"></i>
+				</div>
+				<div class="stats-viewcount card card-header border-0 p-2 overflow-hidden rounded-1 d-flex flex-column align-items-center">
+					<span class="fs-5 ff-secondary lh-1" title="{./viewcount}">{humanReadableNumber(./viewcount, 0)}</span>
+					<span class="d-none d-xl-flex text-lowercase text-xs">[[global:views]]</span>
+					<i class="d-xl-none fa fa-fw text-xs text-muted opacity-75 fa-eye"></i>
+				</div>
+			</div>
+			<div component="topic/teaser" class="meta teaser col-lg-6 col-12 {{{ if !config.theme.mobileTopicTeasers }}}d-none d-lg-block{{{ end }}}">
+				<div class="lastpost border-start border-2 lh-sm h-100 d-flex flex-column gap-1" style="border-color: {./category.bgColor}!important;">
+					{{{ if ./unreplied }}}
+					<div class="ps-2 text-xs">
+						[[category:no-replies]]
+					</div>
+					{{{ else }}}
+					{{{ if ./teaser.pid }}}
+					<div class="ps-2">
+						<a href="{{{ if ./teaser.user.userslug }}}{config.relative_path}/user/{./teaser.user.userslug}{{{ else }}}#{{{ end }}}" class="text-decoration-none">{buildAvatar(./teaser.user, "18px", true, "avatar-tooltip not-responsive")}</a>
+						<a class="permalink text-muted timeago text-xs" href="{config.relative_path}/topic/{./slug}/{./teaser.index}" title="{./teaser.timestampISO}" aria-label="[[global:lastpost]]"></a>
+					</div>
+					<div class="post-content text-xs ps-2 line-clamp-sm-2 lh-sm text-break position-relative flex-fill">
+						<a class="stretched-link" tabindex="-1" href="{config.relative_path}/topic/{./slug}/{./teaser.index}" aria-label="[[global:lastpost]]"></a>
+						{./teaser.content}
+					</div>
+					{{{ end }}}
+					{{{ end }}}
+				</div>
+			</div>
+		</div>
+	</li>
+	{{{end}}}
+</ul>

--- a/nodebb-theme-slackers/templates/topic.tpl
+++ b/nodebb-theme-slackers/templates/topic.tpl
@@ -1,0 +1,126 @@
+<!-- IMPORT partials/breadcrumbs-json-ld.tpl -->
+{{{ if config.theme.enableBreadcrumbs }}}
+<!-- IMPORT partials/breadcrumbs.tpl -->
+{{{ end }}}
+{{{ if widgets.header.length }}}
+<div data-widget-area="header">
+{{{each widgets.header}}}
+{{widgets.header.html}}
+{{{end}}}
+</div>
+{{{ end }}}
+
+<div itemid="{url}" itemscope itemtype="https://schema.org/DiscussionForumPosting">
+	<meta itemprop="headline" content="{escape(titleRaw)}">
+	<meta itemprop="text" content="{escape(titleRaw)}">
+	<meta itemprop="url" content="{url}">
+	<meta itemprop="datePublished" content="{timestampISO}">
+	<meta itemprop="dateModified" content="{lastposttimeISO}">
+	<div itemprop="author" itemscope itemtype="https://schema.org/Person">
+		<meta itemprop="name" content="{author.username}">
+		{{{ if author.userslug }}}<meta itemprop="url" content="{config.relative_path}/user/{author.userslug}">{{{ end }}}
+	</div>
+
+	<div class="d-flex flex-column gap-3">
+		<div class="d-flex flex-wrap">
+			<div class="d-flex flex-column gap-3 flex-grow-1">
+				<h1 component="post/header" class="tracking-tight fw-semibold fs-3 mb-0 text-break {{{ if config.theme.centerHeaderElements }}}text-center{{{ end }}}">
+					<span class="topic-title" component="topic/title">{title}</span>
+				</h1>
+
+				<div class="topic-info d-flex gap-2 align-items-center flex-wrap {{{ if config.theme.centerHeaderElements }}}justify-content-center{{{ end }}}">
+					<span component="topic/labels" class="d-flex gap-2 {{{ if (!scheduled && (!pinned && (!locked && (!oldCid && !icons.length)))) }}}hidden{{{ end }}}">
+						<span component="topic/scheduled" class="badge badge border border-gray-300 text-body {{{ if !scheduled }}}hidden{{{ end }}}">
+							<i class="fa fa-clock-o"></i> [[topic:scheduled]]
+						</span>
+						<span component="topic/pinned" class="badge badge border border-gray-300 text-body {{{ if (scheduled || !pinned) }}}hidden{{{ end }}}">
+							<i class="fa fa-thumb-tack"></i> {{{ if !pinExpiry }}}[[topic:pinned]]{{{ else }}}[[topic:pinned-with-expiry, {isoTimeToLocaleString(./pinExpiryISO, config.userLang)}]]{{{ end }}}
+						</span>
+						<span component="topic/locked" class="badge badge border border-gray-300 text-body {{{ if !locked }}}hidden{{{ end }}}">
+							<i class="fa fa-lock"></i> [[topic:locked]]
+						</span>
+                        <span component="topic/answered" class="badge badge border border-gray-300 text-body {{{ if !answered }}}hidden{{{ end }}}">
+							<i class="fa fa-lock"></i> [[topic:answered]]
+						</span>
+						<a component="topic/moved" href="{config.relative_path}/category/{oldCid}" class="badge badge border border-gray-300 text-body text-decoration-none {{{ if !oldCid }}}hidden{{{ end }}}">
+							<i class="fa fa-arrow-circle-right"></i> {{{ if privileges.isAdminOrMod }}}[[topic:moved-from, {oldCategory.name}]]{{{ else }}}[[topic:moved]]{{{ end }}}
+						</a>
+						{{{each icons}}}<span class="lh-1">{@value}</span>{{{end}}}
+					</span>
+					{function.buildCategoryLabel, category, "a", "border"}
+					<div data-tid="{./tid}" component="topic/tags" class="lh-1 tags tag-list d-flex flex-wrap hidden-xs hidden-empty gap-2"><!-- IMPORT partials/topic/tags.tpl --></div>
+					<div class="d-flex hidden-xs gap-2"><!-- IMPORT partials/topic/stats.tpl --></div>
+				</div>
+			</div>
+			<div class="d-flex gap-2 justify-content-end align-items-center mt-2 hidden-empty" component="topic/thumb/list"><!-- IMPORT partials/topic/thumbs.tpl --></div>
+		</div>
+
+		<div class="row mb-4 mb-lg-0">
+			<div class="topic {{{ if widgets.sidebar.length }}}col-lg-9 col-sm-12{{{ else }}}col-lg-12{{{ end }}}">
+				<!-- IMPORT partials/post_bar.tpl -->
+				{{{ if merger }}}
+				<!-- IMPORT partials/topic/merged-message.tpl -->
+				{{{ end }}}
+				{{{ if forker }}}
+				<!-- IMPORT partials/topic/forked-message.tpl -->
+				{{{ end }}}
+				{{{ if !scheduled }}}
+				<!-- IMPORT partials/topic/deleted-message.tpl -->
+				{{{ end }}}
+
+				<div class="d-flex gap-0 gap-lg-5">
+					<div class="posts-container" style="min-width: 0;">
+						<ul component="topic" class="posts timeline list-unstyled mt-sm-2 p-0 py-3" style="min-width: 0;" data-tid="{tid}" data-cid="{cid}">
+						{{{ each posts }}}
+							<li component="post" class="pt-4 {{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
+								<a component="post/anchor" data-index="{./index}" id="{increment(./index, "1")}"></a>
+								<meta itemprop="datePublished" content="{./timestampISO}">
+								{{{ if ./editedISO }}}
+								<meta itemprop="dateModified" content="{./editedISO}">
+								{{{ end }}}
+
+								<!-- IMPORT partials/topic/post.tpl -->
+							</li>
+							{{{ if (config.topicPostSort != "most_votes") }}}
+							{{{ each ./events}}}<!-- IMPORT partials/topic/event.tpl -->{{{ end }}}
+							{{{ end }}}
+						{{{ end }}}
+						</ul>
+						{{{ if browsingUsers }}}
+						<div class="visible-xs">
+							<!-- IMPORT partials/topic/browsing-users.tpl -->
+							<hr/>
+						</div>
+						{{{ end }}}
+						{{{ if config.theme.enableQuickReply }}}
+						<!-- IMPORT partials/topic/quickreply.tpl -->
+						{{{ end }}}
+					</div>
+
+					<!-- IMPORT partials/topic/navigator.tpl -->
+				</div>
+
+				{{{ if config.usePagination }}}
+				<!-- IMPORT partials/paginator.tpl -->
+				{{{ end }}}
+			</div>
+			<div data-widget-area="sidebar" class="col-lg-3 col-sm-12 {{{ if !widgets.sidebar.length }}}hidden{{{ end }}}">
+			{{{each widgets.sidebar}}}
+			{{widgets.sidebar.html}}
+			{{{end}}}
+			</div>
+		</div>
+	</div>
+</div>
+
+<div data-widget-area="footer">
+{{{each widgets.footer}}}
+{{widgets.footer.html}}
+{{{end}}}
+</div>
+
+{{{ if !config.usePagination }}}
+<noscript>
+<!-- IMPORT partials/paginator.tpl -->
+</noscript>
+{{{ end }}}

--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -112,6 +112,8 @@
 	"thread-tools.unpin": "Unpin Topic",
 	"thread-tools.lock": "Lock Topic",
 	"thread-tools.unlock": "Unlock Topic",
+    "thread-tools.answer": "Answer Question",
+    "thread-tools.unanswer": "Unanswer Question",
 	"thread-tools.move": "Move Topic",
 	"thread-tools.move-posts": "Move Posts",
 	"thread-tools.move-all": "Move All",

--- a/public/language/en-US/topic.json
+++ b/public/language/en-US/topic.json
@@ -99,6 +99,8 @@
     "thread-tools.unpin": "Unpin Topic",
     "thread-tools.lock": "Lock Topic",
     "thread-tools.unlock": "Unlock Topic",
+    "thread-tools.answer": "Answer Question",
+    "thread-tools.unanswer": "Unanswer Question",
     "thread-tools.move": "Move Topic",
     "thread-tools.move-posts": "Move Posts",
     "thread-tools.move-all": "Move All",

--- a/public/language/en-x-pirate/topic.json
+++ b/public/language/en-x-pirate/topic.json
@@ -99,6 +99,8 @@
     "thread-tools.unpin": "Unpin Topic",
     "thread-tools.lock": "Lock Topic",
     "thread-tools.unlock": "Unlock Topic",
+    "thread-tools.answer": "Answer Question",
+    "thread-tools.unanswer": "Unanswer Question",
     "thread-tools.move": "Move Topic",
     "thread-tools.move-posts": "Move Posts",
     "thread-tools.move-all": "Move All",

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -225,6 +225,8 @@ TopicObjectSlim:
           type: string
         locked:
           type: number
+        answered:
+          type: number
         pinned:
           type: number
           description: Whether or not this particular topic is pinned to the top of the

--- a/public/openapi/read/tags/tag.yaml
+++ b/public/openapi/read/tags/tag.yaml
@@ -66,6 +66,8 @@ get:
                           type: number
                         locked:
                           type: number
+                        answered:
+                          type: number
                         pinned:
                           type: number
                           description: Whether or not this particular topic is pinned to the top of the

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -144,6 +144,8 @@ paths:
     $ref: 'write/topics/tid/state.yaml'
   /topics/{tid}/lock:
     $ref: 'write/topics/tid/lock.yaml'
+  /topics/{tid}/answer:
+    $ref: 'write/topics/tid/answer.yaml'
   /topics/{tid}/pin:
     $ref: 'write/topics/tid/pin.yaml'
   /topics/{tid}/follow:

--- a/public/openapi/write/topics/tid/answer.yaml
+++ b/public/openapi/write/topics/tid/answer.yaml
@@ -1,0 +1,52 @@
+put:
+  tags:
+    - topics
+  summary: answer a topic
+  description: This operation answers an existing topic.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully answered
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}
+delete:
+  tags:
+    - topics
+  summary: unanswer a topic
+  description: This operation unanswers a topic.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully unanswered
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/public/src/client/category/tools.js
+++ b/public/src/client/category/tools.js
@@ -46,6 +46,16 @@ define('forum/category/tools', [
 			return false;
 		});
 
+		components.get('topic/answer').on('click', function () {
+			categoryCommand('put', '/answer', 'answer', onCommandComplete);
+			return false;
+		});
+
+		components.get('topic/unanswer').on('click', function () {
+			categoryCommand('del', '/answer', 'unanswer', onCommandComplete);
+			return false;
+		});
+
 		components.get('topic/pin').on('click', function () {
 			categoryCommand('put', '/pin', 'pin', onCommandComplete);
 			return false;
@@ -134,6 +144,8 @@ define('forum/category/tools', [
 		socket.on('event:topic_purged', onTopicPurged);
 		socket.on('event:topic_locked', setLockedState);
 		socket.on('event:topic_unlocked', setLockedState);
+		socket.on('event:topic_answered', setAnsweredState);
+		socket.on('event:topic_unanswered', setAnsweredState);
 		socket.on('event:topic_pinned', setPinnedState);
 		socket.on('event:topic_unpinned', setPinnedState);
 		socket.on('event:topic_moved', onTopicMoved);
@@ -180,6 +192,8 @@ define('forum/category/tools', [
 		socket.removeListener('event:topic_purged', onTopicPurged);
 		socket.removeListener('event:topic_locked', setLockedState);
 		socket.removeListener('event:topic_unlocked', setLockedState);
+		socket.removeListener('event:topic_answered', setAnsweredState);
+		socket.removeListener('event:topic_unanswered', setAnsweredState);
 		socket.removeListener('event:topic_pinned', setPinnedState);
 		socket.removeListener('event:topic_unpinned', setPinnedState);
 		socket.removeListener('event:topic_moved', onTopicMoved);
@@ -211,6 +225,7 @@ define('forum/category/tools', [
 		const areAllDeleted = areAll(isTopicDeleted, tids);
 		const isAnyPinned = isAny(isTopicPinned, tids);
 		const isAnyLocked = isAny(isTopicLocked, tids);
+		const isAnyAnswered = isAny(isTopicAnswered, tids);
 		const isAnyScheduled = isAny(isTopicScheduled, tids);
 		const areAllScheduled = areAll(isTopicScheduled, tids);
 
@@ -220,6 +235,9 @@ define('forum/category/tools', [
 
 		components.get('topic/lock').toggleClass('hidden', isAnyLocked);
 		components.get('topic/unlock').toggleClass('hidden', !isAnyLocked);
+
+		components.get('topic/answer').toggleClass('hidden', isAnyAnswered);
+		components.get('topic/unanswer').toggleClass('hidden', !isAnyAnswered);
 
 		components.get('topic/pin').toggleClass('hidden', areAllScheduled || isAnyPinned);
 		components.get('topic/unpin').toggleClass('hidden', areAllScheduled || !isAnyPinned);
@@ -253,6 +271,10 @@ define('forum/category/tools', [
 		return getTopicEl(tid).hasClass('locked');
 	}
 
+	function isTopicAnswered(tid) {
+		return getTopicEl(tid).hasClass('answered');
+	}
+
 	function isTopicPinned(tid) {
 		return getTopicEl(tid).hasClass('pinned');
 	}
@@ -282,6 +304,12 @@ define('forum/category/tools', [
 		const topic = getTopicEl(data.tid);
 		topic.toggleClass('locked', data.isLocked);
 		topic.find('[component="topic/locked"]').toggleClass('hidden', !data.isLocked);
+	}
+
+	function setAnsweredState(data) {
+		const topic = getTopicEl(data.tid);
+		topic.toggleClass('answered', data.isAnswered);
+		topic.find('[component="topic/answered"]').toggleClass('hidden', !data.isAnswered);
 	}
 
 	function onTopicMoved(data) {

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -26,6 +26,9 @@ define('forum/topic/events', [
 		'event:topic_locked': threadTools.setLockedState,
 		'event:topic_unlocked': threadTools.setLockedState,
 
+		'event:topic_answered': threadTools.setAnsweredState,
+		'event:topic_unanswered': threadTools.setAnsweredState,
+
 		'event:topic_pinned': threadTools.setPinnedState,
 		'event:topic_unpinned': threadTools.setPinnedState,
 

--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -68,7 +68,7 @@ define('forum/topic/posts', [
 			post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
 			post.display_move_tools = ajaxify.data.privileges.isAdminOrMod;
 			post.display_post_menu = ajaxify.data.privileges.isAdminOrMod ||
-				(post.selfPost && !ajaxify.data.locked && !post.deleted) ||
+				(post.selfPost && !ajaxify.data.locked && !ajaxify.data.answered && !post.deleted) ||
 				(post.selfPost && post.deleted && parseInt(post.deleterUid, 10) === parseInt(app.user.uid, 10)) ||
 				((app.user.uid || ajaxify.data.postSharing.length) && !post.deleted);
 		});

--- a/public/src/modules/helpers.common.js
+++ b/public/src/modules/helpers.common.js
@@ -156,7 +156,7 @@ module.exports = function (utils, Benchpress, relative_path) {
 	}
 
 	function generateTopicClass(topic) {
-		const fields = ['locked', 'pinned', 'deleted', 'unread', 'scheduled'];
+		const fields = ['locked', 'answered', 'pinned', 'deleted', 'unread', 'scheduled'];
 		return fields.filter(field => !!topic[field]).join(' ');
 	}
 

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -161,6 +161,18 @@ topicsAPI.unlock = async function (caller, data) {
 	});
 };
 
+topicsAPI.answer = async function (caller, data) {
+	await doTopicAction('answer', 'event:topic_answered', caller, {
+		tids: data.tids,
+	});
+};
+
+topicsAPI.unanswer = async function (caller, data) {
+	await doTopicAction('unanswer', 'event:topic_unanswered', caller, {
+		tids: data.tids,
+	});
+};
+
 topicsAPI.follow = async function (caller, data) {
 	await topics.follow(data.tid, caller.uid);
 };

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -85,6 +85,16 @@ Topics.unlock = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Topics.answer = async (req, res) => {
+	await api.topics.answer(req, { tids: [req.params.tid] });
+	helpers.formatApiResponse(200, res);
+};
+
+Topics.unanswer = async (req, res) => {
+	await api.topics.unanswer(req, { tids: [req.params.tid] });
+	helpers.formatApiResponse(200, res);
+};
+
 Topics.follow = async (req, res) => {
 	await api.topics.follow(req, req.params);
 	helpers.formatApiResponse(200, res);

--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -150,6 +150,11 @@ privsPosts.canEdit = async function (pid, uid) {
 		return { flag: false, message: '[[error:topic-locked]]' };
 	}
 
+	const isAnswered = await topics.isAnswered(results.postData.tid);
+	if (!results.isMod && isAnswered) {
+		return { flag: false, message: '[[error:topic-answered]]' };
+	}
+
 	if (!results.isMod && results.postData.deleted && parseInt(uid, 10) !== parseInt(results.postData.deleterUid, 10)) {
 		return { flag: false, message: '[[error:post-deleted]]' };
 	}
@@ -167,6 +172,7 @@ privsPosts.canDelete = async function (pid, uid) {
 		isAdmin: user.isAdministrator(uid),
 		isMod: posts.isModerator([pid], uid),
 		isLocked: topics.isLocked(postData.tid),
+		isAnswered: topics.isAnswered(postData.tid),
 		isOwner: posts.isOwner(pid, uid),
 		'posts:delete': privsPosts.can('posts:delete', pid, uid),
 	});
@@ -177,6 +183,10 @@ privsPosts.canDelete = async function (pid, uid) {
 
 	if (!results.isMod && results.isLocked) {
 		return { flag: false, message: '[[error:topic-locked]]' };
+	}
+
+	if (!results.isMod && results.isAnswered) {
+		return { flag: false, message: '[[error:topic-answered]]' };
 	}
 
 	const { postDeleteDuration } = meta.config;

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -22,7 +22,7 @@ privsTopics.get = async function (tid, uid) {
 		'posts:upvote', 'posts:downvote',
 		'posts:delete', 'posts:view_deleted', 'read', 'purge',
 	];
-	const topicData = await topics.getTopicFields(tid, ['cid', 'uid', 'locked', 'deleted', 'scheduled']);
+	const topicData = await topics.getTopicFields(tid, ['cid', 'uid', 'locked', 'answered', 'deleted', 'scheduled']);
 	const [userPrivileges, isAdministrator, isModerator, disabled] = await Promise.all([
 		helpers.isAllowedTo(privs, uid, topicData.cid),
 		user.isAdministrator(uid),
@@ -37,16 +37,16 @@ privsTopics.get = async function (tid, uid) {
 	const mayReply = privsTopics.canViewDeletedScheduled(topicData, {}, false, privData['topics:schedule']);
 
 	return await plugins.hooks.fire('filter:privileges.topics.get', {
-		'topics:reply': (privData['topics:reply'] && ((!topicData.locked && mayReply) || isModerator)) || isAdministrator,
+		'topics:reply': (privData['topics:reply'] && ((!topicData.locked && !topicData.answered && mayReply) || isModerator)) || isAdministrator,
 		'topics:read': privData['topics:read'] || isAdministrator,
 		'topics:schedule': privData['topics:schedule'] || isAdministrator,
 		'topics:tag': privData['topics:tag'] || isAdministrator,
 		'topics:delete': (privData['topics:delete'] && (isOwner || isModerator)) || isAdministrator,
-		'posts:edit': (privData['posts:edit'] && (!topicData.locked || isModerator)) || isAdministrator,
+		'posts:edit': (privData['posts:edit'] && ((!topicData.locked && !topicData.answered) || isModerator)) || isAdministrator,
 		'posts:history': privData['posts:history'] || isAdministrator,
 		'posts:upvote': privData['posts:upvote'] || isAdministrator,
 		'posts:downvote': privData['posts:downvote'] || isAdministrator,
-		'posts:delete': (privData['posts:delete'] && (!topicData.locked || isModerator)) || isAdministrator,
+		'posts:delete': (privData['posts:delete'] && ((!topicData.locked && !topicData.answered) || isModerator)) || isAdministrator,
 		'posts:view_deleted': privData['posts:view_deleted'] || isAdministrator,
 		read: privData.read || isAdministrator,
 		purge: (privData.purge && (isOwner || isModerator)) || isAdministrator,

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -27,6 +27,9 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:tid/lock', [...middlewares], controllers.write.topics.lock);
 	setupApiRoute(router, 'delete', '/:tid/lock', [...middlewares], controllers.write.topics.unlock);
 
+	setupApiRoute(router, 'put', '/:tid/answer', [...middlewares], controllers.write.topics.answer);
+	setupApiRoute(router, 'delete', '/:tid/answer', [...middlewares], controllers.write.topics.unanswer);
+
 	setupApiRoute(router, 'put', '/:tid/follow', [...middlewares, middleware.assert.topic], controllers.write.topics.follow);
 	setupApiRoute(router, 'delete', '/:tid/follow', [...middlewares, middleware.assert.topic], controllers.write.topics.unfollow);
 	setupApiRoute(router, 'put', '/:tid/ignore', [...middlewares, middleware.assert.topic], controllers.write.topics.ignore);

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -294,7 +294,7 @@ module.exports = function (Topics) {
 			throw new Error('[[error:no-topic]]');
 		}
 		const { tid, uid } = data;
-		const { cid, deleted, locked, scheduled } = topicData;
+		const { cid, deleted, locked, answered, scheduled } = topicData;
 
 		const [canReply, canSchedule, isAdminOrMod] = await Promise.all([
 			privileges.topics.can('topics:reply', tid, uid),
@@ -304,6 +304,10 @@ module.exports = function (Topics) {
 
 		if (locked && !isAdminOrMod) {
 			throw new Error('[[error:topic-locked]]');
+		}
+
+		if (answered && !isAdminOrMod) {
+			throw new Error('[[error:topic-answered]]');
 		}
 
 		if (!scheduled && deleted && !isAdminOrMod) {

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -12,7 +12,7 @@ const intFields = [
 	'tid', 'cid', 'uid', 'mainPid', 'postcount',
 	'viewcount', 'postercount', 'deleted', 'locked', 'pinned',
 	'pinExpiry', 'timestamp', 'upvotes', 'downvotes', 'lastposttime',
-	'deleterUid',
+	'deleterUid', 'answered',
 ];
 
 module.exports = function (Topics) {

--- a/src/topics/events.js
+++ b/src/topics/events.js
@@ -44,6 +44,14 @@ Events._types = {
 		icon: 'fa-unlock',
 		translation: async (event, language) => translateSimple(event, language, 'topic:user-unlocked-topic'),
 	},
+	answer: {
+		icon: 'fa-lock',
+		translation: async (event, language) => translateSimple(event, language, 'topic:user-locked-topic'),
+	},
+	unanswer: {
+		icon: 'fa-unlock',
+		translation: async (event, language) => translateSimple(event, language, 'topic:user-unlocked-topic'),
+	},
 	delete: {
 		icon: 'fa-trash',
 		translation: async (event, language) => translateSimple(event, language, 'topic:user-deleted-topic'),

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -297,6 +297,11 @@ Topics.isLocked = async function (tid) {
 	return locked === 1;
 };
 
+Topics.isAnswered = async function (tid) {
+	const answered = await Topics.getTopicField(tid, 'answered');
+	return answered === 1;
+};
+
 Topics.search = async function (tid, term) {
 	if (!tid || !term) {
 		throw new Error('[[error:invalid-data]]');

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -165,7 +165,7 @@ module.exports = function (Topics) {
 				post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
 				post.display_move_tools = topicPrivileges.isAdminOrMod && post.index !== 0;
 				post.display_post_menu = topicPrivileges.isAdminOrMod ||
-					(post.selfPost && !topicData.locked && !post.deleted) ||
+					(post.selfPost && !topicData.answered && !topicData.locked && !post.deleted) ||
 					(post.selfPost && post.deleted && parseInt(post.deleterUid, 10) === parseInt(topicPrivileges.uid, 10)) ||
 					((loggedIn || topicData.postSharing.length) && !post.deleted);
 				post.ip = topicPrivileges.isAdminOrMod ? post.ip : undefined;

--- a/test/template-helpers.js
+++ b/test/template-helpers.js
@@ -107,8 +107,8 @@ describe('helpers', () => {
 	});
 
 	it('should generate topic class', (done) => {
-		const className = helpers.generateTopicClass({ locked: true, pinned: true, deleted: true, unread: true });
-		assert.equal(className, 'locked pinned deleted unread');
+		const className = helpers.generateTopicClass({ locked: true, answered: true, pinned: true, deleted: true, unread: true });
+		assert.equal(className, 'locked answered pinned deleted unread');
 		done();
 	});
 

--- a/test/template-helpers.js
+++ b/test/template-helpers.js
@@ -107,11 +107,9 @@ describe('helpers', () => {
 	});
 
 	it('should generate topic class', (done) => {
-		const className = helpers.generateTopicClass({ locked: true, 
-			                                           answered: true, 
-													   pinned: true, 
-													   deleted: true, 
-													   unread: true });
+		const className = helpers.generateTopicClass(
+			{ locked: true, answered: true, pinned: true, deleted: true, unread: true }
+		);
 		assert.equal(className, 'locked answered pinned deleted unread');
 		done();
 	});

--- a/test/template-helpers.js
+++ b/test/template-helpers.js
@@ -107,7 +107,11 @@ describe('helpers', () => {
 	});
 
 	it('should generate topic class', (done) => {
-		const className = helpers.generateTopicClass({ locked: true, answered: true, pinned: true, deleted: true, unread: true });
+		const className = helpers.generateTopicClass({ locked: true, 
+			                                           answered: true, 
+													   pinned: true, 
+													   deleted: true, 
+													   unread: true });
 		assert.equal(className, 'locked answered pinned deleted unread');
 		done();
 	});

--- a/test/topics.js
+++ b/test/topics.js
@@ -414,6 +414,7 @@ describe('Topic\'s', () => {
 				assert.strictEqual(topicData.votes, 0);
 				assert.strictEqual(topicData.deleted, 0);
 				assert.strictEqual(topicData.locked, 0);
+				assert.strictEqual(topicData.answered, 0);
 				assert.strictEqual(topicData.pinned, 0);
 				done();
 			});
@@ -463,6 +464,7 @@ describe('Topic\'s', () => {
 				assert.equal(data.unreplied, false);
 				assert.equal(data.deleted, false);
 				assert.equal(data.locked, false);
+				assert.equal(data.answered, false);
 				assert.equal(data.pinned, false);
 			});
 
@@ -682,10 +684,22 @@ describe('Topic\'s', () => {
 			assert(isLocked);
 		});
 
+		it('should answer topic', async () => {
+			await apiTopics.answer({ uid: adminUid }, { tids: [newTopic.tid], cid: categoryObj.cid });
+			const isAnswered = await topics.isAnswered(newTopic.tid);
+			assert(isAnswered);
+		});
+
+		it('should unanswer topic', async () => {
+			await apiTopics.unanswer({ uid: adminUid }, { tids: [newTopic.tid], cid: categoryObj.cid });
+			const isAnswered = await topics.isAnswered(newTopic.tid);
+			assert(isAnswered);
+		});
+
 		it('should unlock topic', async () => {
 			await apiTopics.unlock({ uid: adminUid }, { tids: [newTopic.tid], cid: categoryObj.cid });
-			const isLocked = await topics.isLocked(newTopic.tid);
-			assert(!isLocked);
+			const isAnswered = await topics.isAnswered(newTopic.tid);
+			assert(!isAnswered);
 		});
 
 		it('should pin topic', async () => {

--- a/test/topics.js
+++ b/test/topics.js
@@ -693,7 +693,7 @@ describe('Topic\'s', () => {
 		it('should unanswer topic', async () => {
 			await apiTopics.unanswer({ uid: adminUid }, { tids: [newTopic.tid], cid: categoryObj.cid });
 			const isAnswered = await topics.isAnswered(newTopic.tid);
-			assert(isAnswered);
+			assert(!isAnswered);
 		});
 
 		it('should unlock topic', async () => {


### PR DESCRIPTION
Upon starting this, I realized that I had done the backend for posts which I thought were topics. At this point I redid the entire backend for topics and figured out the frontend.

- I imported the partial themes into our repo. I then updated them to display an answer post dropdown on the toggle button.
- I added yaml files for the topics to setup the api requests.
- I added the backend logic that toggles the topic data.
- I added the logic that displays a tag on the topic when answered.
- I added the logic that changes the dropdown from answer to unanswer.
- I added test cases to ensure that the data field was toggling correctly.

TESTING
- I used npm test to make sure that all test cases were passing.
- I triggered the button through the front end to visually verify that the tag was changing.
- At this time my build stopped working so I can't upload a video but will as soon as possible.


https://github.com/user-attachments/assets/dc88054c-f4f3-4539-85f2-66ebb5275f2a

This closes:
#resolve https://github.com/CMU-313/nodebb-f24-slackers/issues/2
#resolve https://github.com/CMU-313/nodebb-f24-slackers/issues/11
#resolve https://github.com/CMU-313/nodebb-f24-slackers/issues/5
